### PR TITLE
Remove execstack on JNA libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,8 +33,13 @@ parts:
     override-build: |
       snapcraftctl build
       sed -i 's;@user.home/;@user.home/snap/openchrom/current/;' $SNAPCRAFT_PART_INSTALL/openchrom.ini
+    build-packages:
+      - execstack
     stage-packages:
       - libgtk-3-0
+    override-prime: |
+      craftctl default
+      execstack -c $SNAPCRAFT_PART_INSTALL/plugins/com.sun.jna_*/com/sun/jna/freebsd-*/libjnidispatch.so
   wrappers:
     plugin: dump
     source: snap/local/wrappers


### PR DESCRIPTION
To comply with https://forum.snapcraft.io/t/snap-and-executable-stacks/1812/2