### PR TITLE
Update Docker QEMU action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
           - arm64
     steps:
     - uses: actions/checkout@v4
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v3
     - uses: diddlesnaps/snapcraft-multiarch-action@v1
       id: snapcraft
       with:


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/