### PR TITLE
Use libraries from GNOME extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,7 +51,6 @@ parts:
     stage-packages:
     - libgtk-3-0
     - libusb-1.0-0
-    - libwebkit2gtk-4.1-0
     - libsecret-1-0
     - librsvg2-common
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,6 @@ parts:
     - libgtk-3-0
     - libusb-1.0-0
     - libsecret-1-0
-    - librsvg2-common
     override-prime: |
       craftctl default
       rm -r $SNAPCRAFT_PRIME/plugins/com.sun.jna_*v*/com/sun/jna/aix*/


### PR DESCRIPTION
Closes https://github.com/OpenChrom/openchrom-snap/issues/24

It may be counter intuitive that deleting `/usr/lib/x86_64-linux-gnu/webkit2gtk-4.1/` resolves this because `$SNAP/gnome-platform` already ships it and both are conflicting.