### PR TITLE
Redo wrapper script

### DIFF
--- a/snap/local/wrappers/openchrom
+++ b/snap/local/wrappers/openchrom
@@ -1,10 +1,11 @@
-#!/bin/bash
-EXTRA_ARGS=()
-if [ -f "$SNAP_USER_DATA/openchrom.ini" ]; then
-    # Allow the user to override the openchrom.ini with their own version
-    EXTRA_ARGS+=("--launcher.ini" "$SNAP_USER_DATA/openchrom.ini")
-else
-    echo "To override openchrom.ini, copy the default file to '$SNAP_USER_DATA/openchrom.ini' and modify to suit."
-fi
+export OPENCHROM_HOME="$SNAP_USER_COMMON/openchrom"
+export ECLIPSE_HOME="$SNAP_USER_COMMON/eclipse"
 
-exec "$SNAP/openchrom" -configuration "${SNAP_USER_DATA}/${SNAP_ARCH}/configuration" "${EXTRA_ARGS[@]}" "$@"
+mkdir -p "$OPENCHROM_HOME" "$ECLIPSE_HOME"
+
+exec "$SNAP/openchrom" \
+  -configuration "$ECLIPSE_HOME/configuration" \
+  -data "$OPENCHROM_HOME/workspace" \
+  -vmargs \
+  -Duser.home="$SNAP_USER_COMMON" \
+  "$@"

--- a/snap/local/wrappers/openchrom
+++ b/snap/local/wrappers/openchrom
@@ -6,5 +6,5 @@ if [ -f "$SNAP_USER_DATA/openchrom.ini" ]; then
 else
     echo "To override openchrom.ini, copy the default file to '$SNAP_USER_DATA/openchrom.ini' and modify to suit."
 fi
-GDK_BACKEND=x11
+
 exec "$SNAP/openchrom" -configuration "${SNAP_USER_DATA}/${SNAP_ARCH}/configuration" "${EXTRA_ARGS[@]}" "$@"


### PR DESCRIPTION
This reverts https://github.com/OpenChrom/openchrom-snap/pull/6 partially so we use Wayland instead of X11 which we already default to for @flathub since https://github.com/flathub/com.lablicate.OpenChrom/commit/a12039d808cb5c1ea27cb43cce75d9e6c6caf609 Also the startup script was overly complicated. I bet no one edited the OpenChrom.ini that way. Instead this now defaults to new locations for home that do not break on update. Closes https://github.com/OpenChrom/openchrom-snap/issues/31